### PR TITLE
fix bug with CKR_USER_ALREADY_LOGGED_IN

### DIFF
--- a/pkcs11wrapper/pkcs11.go
+++ b/pkcs11wrapper/pkcs11.go
@@ -87,7 +87,7 @@ func (p11w *Pkcs11Wrapper) Login() (err error) {
 	err = p11w.Context.Login(p11w.Session, pkcs11.CKU_USER, p11w.SlotPin)
 
 	// ignore login error CKR_USER_ALREADY_LOGGED_IN
-	if strings.Contains(err.Error(), "CKR_USER_ALREADY_LOGGED_IN") {
+	if err != nil && strings.Contains(err.Error(), "CKR_USER_ALREADY_LOGGED_IN") {
 		err = nil
 	}
 


### PR DESCRIPTION
Sorry I introduced a bug. This commit will fix a panic when there is no user already logged in :)

Signed-off-by: gbolo <george.bolo@gmail.com>